### PR TITLE
Refactoring logging in the messages_for_broker class to log any non-0…

### DIFF
--- a/lib/poseidon/messages_for_broker.rb
+++ b/lib/poseidon/messages_for_broker.rb
@@ -43,8 +43,10 @@ module Poseidon
       failed = []
       producer_response.topic_response.each do |topic_response|
         topic_response.partitions.each do |partition|
+          # So long as required_acks are != 0, this method will always be invoked during a ProduceRequest
+          # partition[:error] will be the raw error code available in the Errors hash in Poseidon::Errors. It's looked up in ProtocolStruct to determine the error_class
+          Poseidon.logger.error { "Received #{partition.error_class} when attempting to send messages to #{topic_response.topic} on #{partition.partition}" } unless partition[:error] == Poseidon::Errors::NO_ERROR_CODE
           if ALWAYS_RETRYABLE.include?(partition.error_class)
-            Poseidon.logger.debug { "Received #{partition.error_class} when attempting to send messages to #{topic_response.topic} on #{partition.partition}" }
             failed.push(*@topics[topic_response.topic][partition.partition])
           end
         end

--- a/lib/poseidon/messages_for_broker.rb
+++ b/lib/poseidon/messages_for_broker.rb
@@ -45,7 +45,7 @@ module Poseidon
         topic_response.partitions.each do |partition|
           # So long as required_acks are != 0, this method will always be invoked during a ProduceRequest
           # partition[:error] will be the raw error code available in the Errors hash in Poseidon::Errors. It's looked up in ProtocolStruct to determine the error_class
-          Poseidon.logger.error { "Received #{partition.error_class} when attempting to send messages to #{topic_response.topic} on #{partition.partition}" } unless partition[:error] == Poseidon::Errors::NO_ERROR_CODE
+          Poseidon.logger.error { "Poseidon: Received #{partition.error_class} when attempting to send messages to #{topic_response.topic} on #{partition.partition}" } unless partition[:error] == Poseidon::Errors::NO_ERROR_CODE
           if ALWAYS_RETRYABLE.include?(partition.error_class)
             failed.push(*@topics[topic_response.topic][partition.partition])
           end

--- a/lib/poseidon/sync_producer.rb
+++ b/lib/poseidon/sync_producer.rb
@@ -63,7 +63,7 @@ module Poseidon
       end
 
       if messages_to_send.pending_messages?
-        raise "Failed to send all messages: #{messages_to_send.messages} remaining"
+        raise "Poseidon: Failed to send all messages: #{messages_to_send.messages} remaining"
       else
         true
       end
@@ -138,7 +138,7 @@ module Poseidon
       return false if messages_for_broker.broker_id == -1
       to_send = messages_for_broker.build_protocol_objects(@compression_config)
 
-      Poseidon.logger.debug { "Sending messages to broker #{messages_for_broker.broker_id}" }
+      Poseidon.logger.debug { "Poseidon: Sending messages to broker #{messages_for_broker.broker_id}" }
       response = @broker_pool.execute_api_call(messages_for_broker.broker_id, :produce,
                                               required_acks, ack_timeout_ms,
                                               to_send)
@@ -147,7 +147,8 @@ module Poseidon
       else
         messages_for_broker.successfully_sent(response)
       end
-    rescue Connection::ConnectionFailedError, Connection::TimeoutException
+    rescue Connection::ConnectionFailedError, Connection::TimeoutException => e
+      Poseidon.logger.error { "Poseidon: Connection error while sending messages to broker #{messages_for_broker.broker_id}: #{e.message}"}
       false
     end
   end


### PR DESCRIPTION
… response it receives from a ProduceRequest

ping @Tapjoy/eng-group-services 

So, Pfeifer and I talked and ultimately he didn't really care if we did NR or just local logging, we just want more information that we can discover.

Turns out, Poseidon already has a logger! It's using dev/null by default, but we can set it ourselves if we so desire.

If we decide to use NR over this, it should be a fairly easy thing to swap out, so feedback welcome. We'd want to add a line in TJS or wherever we use this library that sets the logger for us (We'd not have the right context for which Logger to use in Toll or Chore-messaging, unless we want to use the Chore.logger, which in the case of TJS is the Rails logger... decisions decisions).
