### PR TITLE
Ignore errors when refreshing metadata

### DIFF
--- a/lib/poseidon/cluster_metadata.rb
+++ b/lib/poseidon/cluster_metadata.rb
@@ -4,7 +4,8 @@ module Poseidon
   #
   # @api private
   class ClusterMetadata
-    attr_reader :brokers, :last_refreshed_at, :topic_metadata
+    attr_accessor :last_refreshed_at
+    attr_reader :brokers, :topic_metadata
     def initialize
       @brokers        = {}
       @topic_metadata = {}

--- a/lib/poseidon/producer.rb
+++ b/lib/poseidon/producer.rb
@@ -79,6 +79,7 @@ module Poseidon
       :metadata_refresh_interval_ms,
       :partitioner,
       :retry_backoff_ms,
+      :metadata_refresh_backoff_ms,
       :required_acks,
       :socket_timeout_ms,
       :connect_timeout_ms,


### PR DESCRIPTION
When refreshing metadata, there's no need to a failure to cause the client to error out.  Instead, just log out the fact that the refresh failed and move on.

Still need to test and verify this change.

/to @Tapjoy/eng-group-services 
