### PR TITLE
When retrying metadata refreshes, sleep based on the configured backoff

### DIFF
--- a/lib/poseidon/sync_producer.rb
+++ b/lib/poseidon/sync_producer.rb
@@ -93,7 +93,7 @@ module Poseidon
       return if !messages_to_send.needs_metadata?
 
       2.times do |n|
-        sleep 5
+        Kernel.sleep retry_backoff_ms / 1000.0
 
         Poseidon.logger.debug { "Fetching metadata for #{messages_to_send.topic_set}. (Attempt #{n+2})" }
         refresh_metadata(messages_to_send.topic_set)


### PR DESCRIPTION
When a metadata refresh results in no metadata for the topic, there's a hard-coded backoff of 5s.  Since we already have a configuration for backoffs, we should use that instead.  Without this, we would run into problems in high-throughput services.

Still need to test / verify this.

/to @Tapjoy/eng-group-services 
