### PR TITLE
allow under-replicated partitions to participate when using keyless m…

### DIFF
--- a/lib/poseidon.rb
+++ b/lib/poseidon.rb
@@ -43,6 +43,8 @@ module Poseidon
     # @api private
     class MessageSizeTooLarge < ProtocolError; end
     # @api private
+    class NotEnoughReplicas < ProtocolError; end
+    # @api private
     class UnrecognizedProtocolError < ProtocolError; end
 
     # @api private
@@ -59,7 +61,8 @@ module Poseidon
       7 => RequestTimedOut,
       8 => BrokerNotAvailable,
       9 => ReplicaNotAvailable,
-      10 => MessageSizeTooLarge
+      10 => MessageSizeTooLarge,
+      19 => NotEnoughReplicas
     }
 
     # Raised when a custom partitioner tries to send

--- a/lib/poseidon/connection.rb
+++ b/lib/poseidon/connection.rb
@@ -113,7 +113,11 @@ module Poseidon
 
     # Explained on http://spin.atomicobject.com/2013/09/30/socket-connection-timeout-ruby/
     def connect_with_timeout(host, port, timeout = 5)
-      addr = Socket.getaddrinfo(host, nil)
+      begin
+        addr = Socket.getaddrinfo(host, nil)
+      rescue SocketError => e
+        raise SystemCallError.new("failed resolving hostname #{host}")
+      end
       sockaddr = Socket.pack_sockaddr_in(port, addr[0][3])
 
       Socket.new(Socket.const_get(addr[0][0]), Socket::SOCK_STREAM, 0).tap do |socket|

--- a/lib/poseidon/messages_for_broker.rb
+++ b/lib/poseidon/messages_for_broker.rb
@@ -37,7 +37,7 @@ module Poseidon
     end
 
     # We can always retry these errors because they mean none of the kafka brokers persisted the message
-    ALWAYS_RETRYABLE = [Poseidon::Errors::LeaderNotAvailable, Poseidon::Errors::NotLeaderForPartition]
+    ALWAYS_RETRYABLE = [Poseidon::Errors::LeaderNotAvailable, Poseidon::Errors::NotLeaderForPartition, Poseidon::Errors::NotEnoughReplicas]
 
     def successfully_sent(producer_response)
       failed = []

--- a/lib/poseidon/topic_metadata.rb
+++ b/lib/poseidon/topic_metadata.rb
@@ -56,7 +56,11 @@ module Poseidon
 
     def available_partitions
       @available_partitions ||= struct.partitions.select do |partition|
-        partition.error == 0 && partition.leader != -1
+        # missing 1 or more replicas (error code 9) should not "blacklist" a partition
+        # there is risk we will try sending messages to leader for a partition that
+        # does not meet 'request.required.acks' if that is set to a positive #, or
+        # 'request.required.acks=-1' && 'min.insync.replicas' on the topic is set > 1
+        (partition.error == 9 || partition.error == 0) && partition.leader != -1
       end
     end
 

--- a/lib/poseidon/version.rb
+++ b/lib/poseidon/version.rb
@@ -1,4 +1,4 @@
 module Poseidon
   # Unstable! API May Change!
-  VERSION = "0.0.5.5"
+  VERSION = "0.0.5.6"
 end


### PR DESCRIPTION
…essages

noticed that when an individual broker is down, all impacted partitions will be taken offline when using "keyless messages / round-robin publishing".  this PR changes that behavior based on the specific error-code associated with impacted partitions in that situation.

as noted in code comments, a potentially undesirable side-effect of this change is that we will attempt to publish to a broker that does not have enough ISRs to accept the message (depending upon how the topic is configured).  at the time of this PR, NRP (new report service) topic is configured to only require 1 replica to accept / confirm a message.
### some notes / observations

return from "topic metadata" request to a kafka broker when all ISRs available (local dev environment):

```
=> [#<Poseidon::TopicMetadata:0x007fe81d025aa0
  @struct=
   #<struct Poseidon::Protocol::TopicMetadataStruct
    error=0,
    name="greg-test",
    partitions=[#<struct Poseidon::Protocol::PartitionMetadata error=0, id=0, leader=0, replicas=[0, 1], isr=[0, 1]>]>>]
```

you can see that the error code associated with partition 0 is 0.  here is the request / result when one of the brokers is down:

```
  [#<Poseidon::TopicMetadata:0x007fcd3d988520
    @struct=
     #<struct Poseidon::Protocol::TopicMetadataStruct
      error=0,
      name="greg-test",
      partitions=[#<struct Poseidon::Protocol::PartitionMetadata error=9, id=0, leader=0, replicas=[0], isr=[0]>]>>]>
```

you can see that the error code associated with partition 0 is 9.

kafka error codes are documented here:
http://kafka.apache.org/protocol.html#protocol_error_codes
you can see that error code 9 ==> replica is down
(this is also how `poseidon` defines it, as one would expect: https://github.com/Tapjoy/poseidon/blob/master/lib/poseidon.rb#L51)

cursory run through kafka's own repo suggests that the only check it makes before adding a partition as "available" when consuming a similar request is to verify that it has a leader:
https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/common/Cluster.java#L118
### potential enhancements / changes to how this PR is implemented:

(1) add code to black-list (and ultimately "clear") a broker if it does not accept publish messages
(2) limited digging around did not reveal a way to determine minimum ISRs for a given topic partition to accept a message; could try to dig into that further, or add a "test publish" message before including a broker as "available" if partition in an error state
(3) change how we "get around" this issue, by going back to keyed messages and providing a custom partitioner that essentially does the same thing as what's in this PR; the only upside being that we avoid modifying core `poseidon` code

ping @Tapjoy/dmmeas 
